### PR TITLE
Adding ESRIServerSource and GeoJSONSource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ REQUIRED_PACKAGES = [
     'fiona==1.8.18',
     'shapely==1.7.1',
     'rasterio==1.1.8',
-    'google-cloud-storage==1.38.0'
+    'google-cloud-storage==1.38.0',
+    'esridump==1.10.1'
 ]
 
 


### PR DESCRIPTION
Hey @tjwebb wanted to send these over - still need to do some testing but wanted to run them by you first.

**GeoJSONSource** - this one should be fairly straightforward as it is a single file and Fiona can read the file natively

**ESRIServerSource** - I added a package that can handle the transformation of ESRI JSON to GeoJSON, as well as loop through a layer request since the ESRI REST API generally limits features that can be requested to 1000 or 2000. I can write some of this code natively or we can use the package, but not sure if we want to limit the dependencies. The package in question is here.

https://github.com/openaddresses/pyesridump

Also any tips for testing locally would be great!